### PR TITLE
feat: add README and tweak Makefile to update workspace cargo file

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,28 +101,6 @@ $ make generate
 🔧   Moving generated files into: `/tmp/my-first-contract-workspace/contracts/first-contract`...
 🔧   Initializing a fresh Git repository
 ✨   Done! New project created /tmp/my-first-contract-workspace/contracts/first-contract
-Please update workspace-level Cargo.toml so members include the newly created crate!
-```
-
-As the log line hints, after creating the contract, we will need to manually update `Cargo.toml` file to contain the newly created contract crate. When you finished editing, `Cargo.toml` file should look like following:
-
-```
-$ cat Cargo.toml
-[workspace]
-resolver = "2"
-
-members = [
-  # Please don't remove the following line, we use it to automatically
-  # detect insertion point for newly generated crates.
-  # @@INSERTION_POINT@@
-  "contracts/first-contract",
-  "tests",
-]
-
-[profile.release]
-overflow-checks = true
-strip = true
-codegen-units = 1
 ```
 
 You can also supply the contract create name when executing the make task:

--- a/atomics-contract/README.md
+++ b/atomics-contract/README.md
@@ -1,0 +1,7 @@
+# {{project-name}}
+
+TODO: Write this readme
+
+*This contract was bootstrapped with [ckb-script-templates].*
+
+[ckb-script-templates]: https://github.com/cryptape/ckb-script-templates

--- a/atomics-contract/cargo-generate.toml
+++ b/atomics-contract/cargo-generate.toml
@@ -1,0 +1,2 @@
+[template]
+cargo_generate_version = ">=0.16.0"

--- a/c-wrapper-crate/README.md
+++ b/c-wrapper-crate/README.md
@@ -1,0 +1,7 @@
+# {{project-name}}
+
+TODO: Write this readme
+
+*This crate was bootstrapped with [ckb-script-templates].*
+
+[ckb-script-templates]: https://github.com/cryptape/ckb-script-templates

--- a/c-wrapper-crate/cargo-generate.toml
+++ b/c-wrapper-crate/cargo-generate.toml
@@ -1,0 +1,2 @@
+[template]
+cargo_generate_version = ">=0.16.0"

--- a/contract/README.md
+++ b/contract/README.md
@@ -1,0 +1,7 @@
+# {{project-name}}
+
+TODO: Write this readme
+
+*This contract was bootstrapped with [ckb-script-templates].*
+
+[ckb-script-templates]: https://github.com/cryptape/ckb-script-templates

--- a/contract/cargo-generate.toml
+++ b/contract/cargo-generate.toml
@@ -1,0 +1,2 @@
+[template]
+cargo_generate_version = ">=0.16.0"

--- a/stack-reorder-contract/README.md
+++ b/stack-reorder-contract/README.md
@@ -1,0 +1,7 @@
+# {{project-name}}
+
+TODO: Write this readme
+
+*This contract was bootstrapped with [ckb-script-templates].*
+
+[ckb-script-templates]: https://github.com/cryptape/ckb-script-templates

--- a/stack-reorder-contract/cargo-generate.toml
+++ b/stack-reorder-contract/cargo-generate.toml
@@ -1,0 +1,2 @@
+[template]
+cargo_generate_version = ">=0.16.0"

--- a/standalone-contract/README.md
+++ b/standalone-contract/README.md
@@ -1,0 +1,7 @@
+# {{project-name}}
+
+TODO: Write this readme
+
+*This contract was bootstrapped with [ckb-script-templates].*
+
+[ckb-script-templates]: https://github.com/cryptape/ckb-script-templates

--- a/standalone-contract/cargo-generate.toml
+++ b/standalone-contract/cargo-generate.toml
@@ -1,0 +1,2 @@
+[template]
+cargo_generate_version = ">=0.16.0"

--- a/workspace/Makefile
+++ b/workspace/Makefile
@@ -72,7 +72,7 @@ fmt:
 # Arbitrary cargo command is supported here. For example:
 #
 # make cargo CARGO_CMD=expand CARGO_ARGS="--ugly"
-# 
+#
 # Invokes:
 # cargo expand --ugly
 CARGO_CMD :=
@@ -93,7 +93,9 @@ generate:
 	if [ "x$(CRATE)" = "x" ]; then \
 		cargo generate $(TEMPLATE_TYPE) $(TEMPLATE_REPO) $(TEMPLATE) \
 			--destination $(DESTINATION); \
-		echo "Please update workspace-level Cargo.toml so members include the newly created crate!"; \
+		GENERATED_DIR=$$(ls -dt $(DESTINATION)/* | head -n 1); \
+		sed "s,@@INSERTION_POINT@@,@@INSERTION_POINT@@\n  \"$$GENERATED_DIR\"\,," Cargo.toml > Cargo.toml.new; \
+		mv Cargo.toml.new Cargo.toml; \
 	else \
 		cargo generate $(TEMPLATE_TYPE) $(TEMPLATE_REPO) $(TEMPLATE) \
 			--destination $(DESTINATION) \

--- a/workspace/README.md
+++ b/workspace/README.md
@@ -1,0 +1,7 @@
+# {{project-name}}
+
+TODO: Write this readme
+
+*This project was bootstrapped with [ckb-script-templates].*
+
+[ckb-script-templates]: https://github.com/cryptape/ckb-script-templates

--- a/workspace/cargo-generate.toml
+++ b/workspace/cargo-generate.toml
@@ -1,0 +1,2 @@
+[template]
+cargo_generate_version = ">=0.16.0"

--- a/x64-simulator-crate/README.md
+++ b/x64-simulator-crate/README.md
@@ -1,0 +1,7 @@
+# {{project-name}}
+
+TODO: Write this readme
+
+*This crate was bootstrapped with [ckb-script-templates].*
+
+[ckb-script-templates]: https://github.com/cryptape/ckb-script-templates

--- a/x64-simulator-crate/cargo-generate.toml
+++ b/x64-simulator-crate/cargo-generate.toml
@@ -1,0 +1,2 @@
+[template]
+cargo_generate_version = ">=0.16.0"


### PR DESCRIPTION
1. added cargo-generate min version requirement ( >=0.16.0)
2. added README template
3. auto update workspace cargo file when generate sub crate and contract