### PR TITLE
Ensure llvm-ar is used as the archiver

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,6 +46,36 @@ jobs:
     - name: Reproducible build runs
       run: cd test-contract && ./scripts/reproducible_build_docker --update && ./scripts/reproducible_build_docker --no-clean
 
+  ubuntu-arm64-docker-build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup qemu binfmt
+      run: docker run --privileged --rm tonistiigi/binfmt --install all
+    - name: Install cargo generate
+      run: cargo install cargo-generate
+    - name: Generate workspace
+      run: cargo generate --path . workspace --name test-workspace
+    - name: Generate crates && contracts
+      run: cd test-workspace &&
+        make generate CRATE=clib TEMPLATE=c-wrapper-crate DESTINATION=crates TEMPLATE_TYPE=--path TEMPLATE_REPO=.. &&
+        make generate CRATE=rlib TEMPLATE=x64-simulator-crate DESTINATION=crates TEMPLATE_TYPE=--path TEMPLATE_REPO=.. &&
+        make generate CRATE=c1 TEMPLATE=contract TEMPLATE_TYPE=--path TEMPLATE_REPO=.. &&
+        make generate CRATE=c2 TEMPLATE=atomics-contract TEMPLATE_TYPE=--path TEMPLATE_REPO=.. &&
+        make generate CRATE=c3 TEMPLATE=stack-reorder-contract TEMPLATE_TYPE=--path TEMPLATE_REPO=..
+    - name: Submodules
+      run: cd test-workspace &&
+        git submodule add https://github.com/nervosnetwork/ckb-c-stdlib deps/ckb-c-stdlib &&
+        git submodule add https://github.com/xxuejie/lib-dummy-atomics deps/lib-dummy-atomics
+    - name: Reproducible build runs
+      run: cd test-workspace && export DOCKER_RUN_ARGS="--platform linux/arm64" && ./scripts/reproducible_build_docker --update && ./scripts/reproducible_build_docker --no-clean
+    - name: Generate standalone contract
+      run: cargo generate --path . standalone-contract --name test-contract
+    - name: Reproducible build runs
+      run: cd test-contract && export DOCKER_RUN_ARGS="--platform linux/arm64" && ./scripts/reproducible_build_docker --update && ./scripts/reproducible_build_docker --no-clean
+
   debian-build:
 
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -128,7 +128,7 @@ jobs:
 
     steps:
     - name: Install dependencies
-      run: sudo dnf -y install clang git make openssl-devel
+      run: sudo dnf -y install clang llvm git make openssl-devel
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         components: clippy
@@ -168,7 +168,7 @@ jobs:
 
     steps:
     - name: Install dependencies
-      run: pacman --noconfirm -Syu clang git make openssl pkgconf
+      run: pacman --noconfirm -Syu clang llvm git make openssl pkgconf
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         components: clippy

--- a/atomics-contract/Makefile
+++ b/atomics-contract/Makefile
@@ -18,6 +18,7 @@ MODE := release
 # Tweak this to change the clang version to use for building C code. By default
 # we use a bash script with somes heuristics to find clang in current system.
 CLANG := $(shell $(TOP)/scripts/find_clang)
+AR := $(subst clang,llvm-ar,$(CLANG))
 # When this is set to some value, the generated binaries will be copied over
 BUILD_DIR :=
 # Generated binaries to copy. By convention, a Rust crate's directory name will
@@ -33,7 +34,7 @@ endif
 default: build test
 
 build:
-	RUSTFLAGS="$(FULL_RUSTFLAGS)" TARGET_CC="$(CLANG)" \
+	RUSTFLAGS="$(FULL_RUSTFLAGS)" TARGET_CC="$(CLANG)" TARGET_AR="$(AR)" \
 		cargo build --target=riscv64imac-unknown-none-elf $(MODE_ARGS) $(CARGO_ARGS)
 	@set -eu; \
 	if [ "x$(BUILD_DIR)" != "x" ]; then \

--- a/contract/Makefile
+++ b/contract/Makefile
@@ -18,6 +18,7 @@ MODE := release
 # Tweak this to change the clang version to use for building C code. By default
 # we use a bash script with somes heuristics to find clang in current system.
 CLANG := $(shell $(TOP)/scripts/find_clang)
+AR := $(subst clang,llvm-ar,$(CLANG))
 # When this is set to some value, the generated binaries will be copied over
 BUILD_DIR :=
 # Generated binaries to copy. By convention, a Rust crate's directory name will
@@ -33,7 +34,7 @@ endif
 default: build test
 
 build:
-	RUSTFLAGS="$(FULL_RUSTFLAGS)" TARGET_CC="$(CLANG)" \
+	RUSTFLAGS="$(FULL_RUSTFLAGS)" TARGET_CC="$(CLANG)" TARGET_AR="$(AR)" \
 		cargo build --target=riscv64imac-unknown-none-elf $(MODE_ARGS) $(CARGO_ARGS)
 	@set -eu; \
 	if [ "x$(BUILD_DIR)" != "x" ]; then \

--- a/stack-reorder-contract/Makefile
+++ b/stack-reorder-contract/Makefile
@@ -19,6 +19,7 @@ MODE := release
 # Tweak this to change the clang version to use for building C code. By default
 # we use a bash script with somes heuristics to find clang in current system.
 CLANG := $(shell $(TOP)/scripts/find_clang)
+AR := $(subst clang,llvm-ar,$(CLANG))
 # When this is set to some value, the generated binaries will be copied over
 BUILD_DIR :=
 # Generated binaries to copy. By convention, a Rust crate's directory name will
@@ -34,7 +35,7 @@ endif
 default: build test
 
 build:
-	RUSTFLAGS="$(FULL_RUSTFLAGS)" TARGET_CC="$(CLANG)" \
+	RUSTFLAGS="$(FULL_RUSTFLAGS)" TARGET_CC="$(CLANG)" TARGET_AR="$(AR)" \
 		cargo build --target=riscv64imac-unknown-none-elf $(MODE_ARGS) $(CARGO_ARGS)
 	@set -eu; \
 	if [ "x$(BUILD_DIR)" != "x" ]; then \

--- a/standalone-contract/Makefile
+++ b/standalone-contract/Makefile
@@ -18,6 +18,7 @@ MODE := release
 # Tweak this to change the clang version to use for building C code. By default
 # we use a bash script with somes heuristics to find clang in current system.
 CLANG := $(shell $(TOP)/scripts/find_clang)
+AR := $(subst clang,llvm-ar,$(CLANG))
 # When this is set to some value, the generated binaries will be copied over
 BUILD_DIR := build/$(MODE)
 # Generated binaries to copy. By convention, a Rust crate's directory name will
@@ -33,7 +34,7 @@ endif
 default: build test
 
 build:
-	RUSTFLAGS="$(FULL_RUSTFLAGS)" TARGET_CC="$(CLANG)" \
+	RUSTFLAGS="$(FULL_RUSTFLAGS)" TARGET_CC="$(CLANG)" TARGET_AR="$(AR)" \
 		cargo build --target=riscv64imac-unknown-none-elf $(MODE_ARGS) $(CARGO_ARGS)
 	mkdir -p $(BUILD_DIR)
 	@set -eu; \


### PR DESCRIPTION
It seems that under certain platform(for example, ubuntu using arm64 CPUs), `cc-rs` would try to use `riscv64-unknown-elf-ar` as the archiver, which could be missing in current LLVM based toolchain. This PR changes the build process so llvm-ar is always used.