### PR TITLE
Disable RISC-V A extension by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 This repository keeps a series of CKB script templates that can be inflated via [cargo-generate](https://github.com/cargo-generate/cargo-generate). Those templates enable a native development flow on mainstream Linux, macOS and Windows machines using stock version of latest stable Rust & clang C compiler.
 
+## Noticeable Changes
+
+### Molecule uses bytes crates
+
+ [molecule](https://github.com/nervosnetwork/molecule) starting from 0.8.0, switches to [bytes](https://crates.io/crates/bytes) instead of `Vec` internally to keep data in `no_std` environment. However, bytes would require atomic builtins so as to function, this could lead to unsupported CKB-VM instructions (RISC-V A extension instructions to be precise) being generated. There are 2 ways to solve this issue:
+
+* Enable `dummy-atomic` feature in `ckb-std` crate, also use make sure `FULL_RUSTFLAGS` in the contract makefile is updated so `-a` is included, for example: `FULL_RUSTFLAGS := -C target-feature=+zba,+zbb,+zbc,+zbs,-a $(CUSTOM_RUSTFLAGS)`. Or see [this PR](https://github.com/cryptape/ckb-script-templates/pull/17) for how to change `RUSTFLAGS`.
+* Enable `bytes_vec` feature in `molecule` crate
+
+[ckb-gen-types](https://crates.io/crates/ckb-gen-types) starting from 0.117.0 is also affected, since `ckb-gen-types` has upgraded to `molecule` 0.8.0 in this version.
+
 ## Usage
 
 ### Dependencies

--- a/contract/Makefile
+++ b/contract/Makefile
@@ -9,7 +9,7 @@ TOP := $(cur_dir)
 CUSTOM_RUSTFLAGS := --cfg debug_assertions
 # RUSTFLAGS that are less likely to be tweaked by developers. Most likely
 # one would want to keep the default values here.
-FULL_RUSTFLAGS := -C target-feature=+zba,+zbb,+zbc,+zbs $(CUSTOM_RUSTFLAGS)
+FULL_RUSTFLAGS := -C target-feature=+zba,+zbb,+zbc,+zbs,-a $(CUSTOM_RUSTFLAGS)
 # Additional cargo args to append here. For example, one can use
 # make test CARGO_ARGS="-- --nocapture" so as to inspect data emitted to
 # stdout in unit tests

--- a/stack-reorder-contract/Makefile
+++ b/stack-reorder-contract/Makefile
@@ -9,7 +9,7 @@ TOP := $(cur_dir)
 CUSTOM_RUSTFLAGS := --cfg debug_assertions
 # RUSTFLAGS that are less likely to be tweaked by developers. Most likely
 # one would want to keep the default values here.
-FULL_RUSTFLAGS := -C target-feature=+zba,+zbb,+zbc,+zbs $(CUSTOM_RUSTFLAGS) \
+FULL_RUSTFLAGS := -C target-feature=+zba,+zbb,+zbc,+zbs,-a $(CUSTOM_RUSTFLAGS) \
 	-C link-arg=-T$(cur_dir)ld_interface.ld
 # Additional cargo args to append here. For example, one can use
 # make test CARGO_ARGS="-- --nocapture" so as to inspect data emitted to

--- a/standalone-contract/Makefile
+++ b/standalone-contract/Makefile
@@ -9,7 +9,7 @@ TOP := $(cur_dir)
 CUSTOM_RUSTFLAGS := --cfg debug_assertions
 # RUSTFLAGS that are less likely to be tweaked by developers. Most likely
 # one would want to keep the default values here.
-FULL_RUSTFLAGS := -C target-feature=+zba,+zbb,+zbc,+zbs $(CUSTOM_RUSTFLAGS)
+FULL_RUSTFLAGS := -C target-feature=+zba,+zbb,+zbc,+zbs,-a $(CUSTOM_RUSTFLAGS)
 # Additional cargo args to append here. For example, one can use
 # make test CARGO_ARGS="-- --nocapture" so as to inspect data emitted to
 # stdout in unit tests


### PR DESCRIPTION
While there is experimental support for A extension in CKB-VM, no CKB versions enable A extension for now. This commit fixes makefile so we are not generating any instruction from A extension by default, which would be a benefit for developers(since they don't have to do this by themselves)