### PR TITLE
Leverage another LLVM binary to locate current clang binary

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,8 +16,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Install llvm 18
-      run: wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 18 && rm llvm.sh
+    - name: Install llvm
+      run: apt update && apt install -y clang # This requires Ubuntu 24.04 or later
     - name: Install cargo generate
       run: cargo install cargo-generate
     - name: Generate workspace
@@ -37,10 +37,8 @@ jobs:
       run: cd test-workspace && echo "1.75.0" > rust-toolchain
     - name: Install riscv64 target
       run: cd test-workspace && rustup target add riscv64imac-unknown-none-elf
-    # TODO: Ubuntu 24.04 ships a clang package with clang, clang-18 and llvm-ar-18, while fedora ships a clang package with
-    # clang, clang-19 and llvm-ar. We will need to deal with this quirk between different distros.
     - name: Run all checks
-      run: cd test-workspace && CLANG=clang-18 make build test check clippy
+      run: cd test-workspace && make build test check clippy
     - name: Reproducible build runs
       run: cd test-workspace && ./scripts/reproducible_build_docker --update && ./scripts/reproducible_build_docker --no-clean
     - name: Generate standalone contract
@@ -48,7 +46,7 @@ jobs:
     - name: Lock Rust version
       run: cd test-contract && echo "1.75.0" > rust-toolchain
     - name: Run all checks
-      run: cd test-contract && CLANG=clang-18 make build test check clippy
+      run: cd test-contract && make build test check clippy
     - name: Reproducible build runs
       run: cd test-contract && ./scripts/reproducible_build_docker --update && ./scripts/reproducible_build_docker --no-clean
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install llvm
-      run: apt update && apt install -y clang # This requires Ubuntu 24.04 or later
+      run: sudo apt update && sudo apt install -y clang # This requires Ubuntu 24.04 or later
     - name: Install cargo generate
       run: cargo install cargo-generate
     - name: Generate workspace

--- a/standalone-contract/scripts/find_clang
+++ b/standalone-contract/scripts/find_clang
@@ -26,7 +26,7 @@ if [[ -n "${BREW_PREFIX}" ]]; then
 fi
 
 for candidate in ${CANDIDATES[@]}; do
-  OUTPUT=$($candidate --version 2> /dev/null | grep 'version [0-9]' | head -n 1 | cut -d'.' -f 1 | rev | cut -d' ' -f 1 | rev)
+  OUTPUT=$($candidate --version 2> /dev/null | grep 'version [0-9]' | head -n 1 | cut -d'.' -f 1 | grep -o '[0-9][0-9]*')
 
   if [[ $((OUTPUT)) -ge 16 ]]; then
     echo "${candidate/${SEARCH_TARGET}/clang}"

--- a/standalone-contract/scripts/find_clang
+++ b/standalone-contract/scripts/find_clang
@@ -7,23 +7,29 @@ if [[ -n "${CLANG}" ]]; then
   exit 0
 fi
 
-CANDIDATES=("clang" "clang-16" "clang-17" "clang-18")
+# To cope with packaging messes from different distros, we would search
+# for a different binary other than clang, then convert it back to clang
+# at the end.
+SEARCH_TARGET="${SEARCH_TARGET:-llvm-strip}"
+
+CANDIDATES=("${SEARCH_TARGET}" "${SEARCH_TARGET}-19" "${SEARCH_TARGET}-18" "${SEARCH_TARGET}-17" "${SEARCH_TARGET}-16")
 
 BREW_PREFIX=$(brew --prefix 2> /dev/null)
 if [[ -n "${BREW_PREFIX}" ]]; then
   CANDIDATES+=(
-    "${BREW_PREFIX}/opt/llvm/bin/clang"
-    "${BREW_PREFIX}/opt/llvm@16/bin/clang"
-    "${BREW_PREFIX}/opt/llvm@17/bin/clang"
-    "${BREW_PREFIX}/opt/llvm@18/bin/clang"
+    "${BREW_PREFIX}/opt/llvm/bin/${SEARCH_TARGET}"
+    "${BREW_PREFIX}/opt/llvm@19/bin/${SEARCH_TARGET}"
+    "${BREW_PREFIX}/opt/llvm@18/bin/${SEARCH_TARGET}"
+    "${BREW_PREFIX}/opt/llvm@17/bin/${SEARCH_TARGET}"
+    "${BREW_PREFIX}/opt/llvm@16/bin/${SEARCH_TARGET}"
   )
 fi
 
 for candidate in ${CANDIDATES[@]}; do
-  OUTPUT=$($candidate -dumpversion 2> /dev/null | cut -d'.' -f 1)
+  OUTPUT=$($candidate --version 2> /dev/null | grep 'version [0-9]' | head -n 1 | cut -d'.' -f 1 | rev | cut -d' ' -f 1 | rev)
 
   if [[ $((OUTPUT)) -ge 16 ]]; then
-    echo "$candidate"
+    echo "${candidate/${SEARCH_TARGET}/clang}"
     exit 0
   fi
 done

--- a/workspace/scripts/find_clang
+++ b/workspace/scripts/find_clang
@@ -26,7 +26,7 @@ if [[ -n "${BREW_PREFIX}" ]]; then
 fi
 
 for candidate in ${CANDIDATES[@]}; do
-  OUTPUT=$($candidate --version 2> /dev/null | grep 'version [0-9]' | head -n 1 | cut -d'.' -f 1 | rev | cut -d' ' -f 1 | rev)
+  OUTPUT=$($candidate --version 2> /dev/null | grep 'version [0-9]' | head -n 1 | cut -d'.' -f 1 | grep -o '[0-9][0-9]*')
 
   if [[ $((OUTPUT)) -ge 16 ]]; then
     echo "${candidate/${SEARCH_TARGET}/clang}"

--- a/workspace/scripts/find_clang
+++ b/workspace/scripts/find_clang
@@ -7,23 +7,29 @@ if [[ -n "${CLANG}" ]]; then
   exit 0
 fi
 
-CANDIDATES=("clang" "clang-16" "clang-17" "clang-18")
+# To cope with packaging messes from different distros, we would search
+# for a different binary other than clang, then convert it back to clang
+# at the end.
+SEARCH_TARGET="${SEARCH_TARGET:-llvm-strip}"
+
+CANDIDATES=("${SEARCH_TARGET}" "${SEARCH_TARGET}-19" "${SEARCH_TARGET}-18" "${SEARCH_TARGET}-17" "${SEARCH_TARGET}-16")
 
 BREW_PREFIX=$(brew --prefix 2> /dev/null)
 if [[ -n "${BREW_PREFIX}" ]]; then
   CANDIDATES+=(
-    "${BREW_PREFIX}/opt/llvm/bin/clang"
-    "${BREW_PREFIX}/opt/llvm@16/bin/clang"
-    "${BREW_PREFIX}/opt/llvm@17/bin/clang"
-    "${BREW_PREFIX}/opt/llvm@18/bin/clang"
+    "${BREW_PREFIX}/opt/llvm/bin/${SEARCH_TARGET}"
+    "${BREW_PREFIX}/opt/llvm@19/bin/${SEARCH_TARGET}"
+    "${BREW_PREFIX}/opt/llvm@18/bin/${SEARCH_TARGET}"
+    "${BREW_PREFIX}/opt/llvm@17/bin/${SEARCH_TARGET}"
+    "${BREW_PREFIX}/opt/llvm@16/bin/${SEARCH_TARGET}"
   )
 fi
 
 for candidate in ${CANDIDATES[@]}; do
-  OUTPUT=$($candidate -dumpversion 2> /dev/null | cut -d'.' -f 1)
+  OUTPUT=$($candidate --version 2> /dev/null | grep 'version [0-9]' | head -n 1 | cut -d'.' -f 1 | rev | cut -d' ' -f 1 | rev)
 
   if [[ $((OUTPUT)) -ge 16 ]]; then
-    echo "$candidate"
+    echo "${candidate/${SEARCH_TARGET}/clang}"
     exit 0
   fi
 done


### PR DESCRIPTION
Different distros package LLVM / clang into different setups:
* Fedora 41's clang package provides clang, clang-19 and llvm-ar
* Ubuntu 24.04's clang package provides clang, clang-18 and llvm-ar-18

Previously, we rely on clang's binary name to infer names for other binaries. But given the above packaging reality, relying on binary clang introduces ambiguity.

This commit changes the code so we now rely on another binary, such as llvm-strip or llvm-strip-18 to detect the suffix, and then piece together the binary names we will invoke.