### PR TITLE
Add extren alloc in lib.rs

### DIFF
--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -5,3 +5,5 @@
 mod main;
 #[cfg(feature = "native-simulator")]
 pub use main::program_entry;
+
+extern crate alloc;


### PR DESCRIPTION
If the developer references multiple files, there will still be problems if they are only imported in main.rs