### PR TITLE
Upgrade reproducible docker image to 20250117

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,7 +39,7 @@ jobs:
         git submodule add https://github.com/nervosnetwork/ckb-c-stdlib deps/ckb-c-stdlib &&
         git submodule add https://github.com/xxuejie/lib-dummy-atomics deps/lib-dummy-atomics
     - name: Lock Rust version
-      run: cd test-workspace && echo "1.75.0" > rust-toolchain
+      run: cd test-workspace && echo "1.81.0" > rust-toolchain
     - name: Install riscv64 target
       run: cd test-workspace && rustup target add riscv64imac-unknown-none-elf
     - name: Run all checks
@@ -49,7 +49,7 @@ jobs:
     - name: Generate standalone contract
       run: cargo generate --path . standalone-contract --name test-contract
     - name: Lock Rust version
-      run: cd test-contract && echo "1.75.0" > rust-toolchain
+      run: cd test-contract && echo "1.81.0" > rust-toolchain
     - name: Run all checks
       run: cd test-contract && make build test check clippy
     - name: Reproducible build runs

--- a/standalone-contract/scripts/reproducible_build_docker
+++ b/standalone-contract/scripts/reproducible_build_docker
@@ -7,8 +7,8 @@
 set -ex
 
 DOCKER="${DOCKER:-docker}"
-# docker pull docker.io/cryptape/llvm-n-rust:20240630
-DOCKER_IMAGE="${DOCKER_IMAGE:-docker.io/cryptape/llvm-n-rust@sha256:bafaf76d4f342a69b8691c08e77a330b7740631f3d1d9c9bee4ead521b29ee55}"
+# docker pull docker.io/cryptape/llvm-n-rust:20250117
+DOCKER_IMAGE="${DOCKER_IMAGE:-docker.io/cryptape/llvm-n-rust@sha256:12e7821cb9c7cbc8988d5b1d60bcc87da4cedcf3eea32df1d8833328c5a69f88}"
 CHECKSUM_FILE_PATH="${CHECKSUM_FILE_PATH:-checksums.txt}"
 
 # We are parsing command line arguments based on tips from:

--- a/workspace/scripts/reproducible_build_docker
+++ b/workspace/scripts/reproducible_build_docker
@@ -7,8 +7,8 @@
 set -ex
 
 DOCKER="${DOCKER:-docker}"
-# docker pull docker.io/cryptape/llvm-n-rust:20240630
-DOCKER_IMAGE="${DOCKER_IMAGE:-docker.io/cryptape/llvm-n-rust@sha256:bafaf76d4f342a69b8691c08e77a330b7740631f3d1d9c9bee4ead521b29ee55}"
+# docker pull docker.io/cryptape/llvm-n-rust:20250117
+DOCKER_IMAGE="${DOCKER_IMAGE:-docker.io/cryptape/llvm-n-rust@sha256:12e7821cb9c7cbc8988d5b1d60bcc87da4cedcf3eea32df1d8833328c5a69f88}"
 CHECKSUM_FILE_PATH="${CHECKSUM_FILE_PATH:-checksums.txt}"
 
 # We are parsing command line arguments based on tips from:


### PR DESCRIPTION
This new docker image is packed with Rust 1.81.0 with LLVM 18.1.8