### PR TITLE
Bump heap size for default alloc

### DIFF
--- a/atomics-contract/src/main.rs
+++ b/atomics-contract/src/main.rs
@@ -5,11 +5,14 @@
 extern crate alloc;
 
 #[cfg(not(test))]
-use ckb_std::default_alloc;
-#[cfg(not(test))]
 ckb_std::entry!(program_entry);
-#[cfg(not(test))]
-default_alloc!();
+// By default, the following heap configuration is used:
+// * 16KB fixed heap
+// * 1.2MB(roughed up to be 16-byte aligned) dynamic heap
+// * Minimal memory block in dynamic heap is 64 bytes
+// For more details, please refer to ckb-std's default_alloc macro
+// and the buddy-alloc alloc implementation.
+ckb_std::default_alloc!(16384, 1258306, 64);
 
 pub fn program_entry() -> i8 {
     log::error!("Just a log line");

--- a/atomics-contract/src/main.rs
+++ b/atomics-contract/src/main.rs
@@ -8,7 +8,7 @@ extern crate alloc;
 ckb_std::entry!(program_entry);
 // By default, the following heap configuration is used:
 // * 16KB fixed heap
-// * 1.2MB(roughed up to be 16-byte aligned) dynamic heap
+// * 1.2MB(rounded up to be 16-byte aligned) dynamic heap
 // * Minimal memory block in dynamic heap is 64 bytes
 // For more details, please refer to ckb-std's default_alloc macro
 // and the buddy-alloc alloc implementation.

--- a/contract/src/main.rs
+++ b/contract/src/main.rs
@@ -9,7 +9,7 @@ ckb_std::entry!(program_entry);
 #[cfg(not(any(feature = "native-simulator", test)))]
 // By default, the following heap configuration is used:
 // * 16KB fixed heap
-// * 1.2MB(roughed up to be 16-byte aligned) dynamic heap
+// * 1.2MB(rounded up to be 16-byte aligned) dynamic heap
 // * Minimal memory block in dynamic heap is 64 bytes
 // For more details, please refer to ckb-std's default_alloc macro
 // and the buddy-alloc alloc implementation.

--- a/contract/src/main.rs
+++ b/contract/src/main.rs
@@ -7,7 +7,13 @@ extern crate alloc;
 #[cfg(not(any(feature = "native-simulator", test)))]
 ckb_std::entry!(program_entry);
 #[cfg(not(any(feature = "native-simulator", test)))]
-ckb_std::default_alloc!();
+// By default, the following heap configuration is used:
+// * 16KB fixed heap
+// * 1.2MB(roughed up to be 16-byte aligned) dynamic heap
+// * Minimal memory block in dynamic heap is 64 bytes
+// For more details, please refer to ckb-std's default_alloc macro
+// and the buddy-alloc alloc implementation.
+ckb_std::default_alloc!(16384, 1258306, 64);
 
 pub fn program_entry() -> i8 {
     ckb_std::debug!("This is a sample contract!");

--- a/stack-reorder-contract/src/main.rs
+++ b/stack-reorder-contract/src/main.rs
@@ -5,11 +5,14 @@
 extern crate alloc;
 
 #[cfg(not(test))]
-use ckb_std::default_alloc;
-#[cfg(not(test))]
 ckb_std::entry!(program_entry);
-#[cfg(not(test))]
-default_alloc!();
+// By default, the following heap configuration is used:
+// * 16KB fixed heap
+// * 1.2MB(roughed up to be 16-byte aligned) dynamic heap
+// * Minimal memory block in dynamic heap is 64 bytes
+// For more details, please refer to ckb-std's default_alloc macro
+// and the buddy-alloc alloc implementation.
+ckb_std::default_alloc!(16384, 1258306, 64);
 
 #[allow(unused_variables, unused_assignments)]
 pub fn program_entry() -> i8 {

--- a/stack-reorder-contract/src/main.rs
+++ b/stack-reorder-contract/src/main.rs
@@ -8,7 +8,7 @@ extern crate alloc;
 ckb_std::entry!(program_entry);
 // By default, the following heap configuration is used:
 // * 16KB fixed heap
-// * 1.2MB(roughed up to be 16-byte aligned) dynamic heap
+// * 1.2MB(rounded up to be 16-byte aligned) dynamic heap
 // * Minimal memory block in dynamic heap is 64 bytes
 // For more details, please refer to ckb-std's default_alloc macro
 // and the buddy-alloc alloc implementation.

--- a/standalone-contract/src/main.rs
+++ b/standalone-contract/src/main.rs
@@ -12,7 +12,7 @@ ckb_std::entry!(program_entry);
 #[cfg(not(test))]
 // By default, the following heap configuration is used:
 // * 16KB fixed heap
-// * 1.2MB(roughed up to be 16-byte aligned) dynamic heap
+// * 1.2MB(rounded up to be 16-byte aligned) dynamic heap
 // * Minimal memory block in dynamic heap is 64 bytes
 // For more details, please refer to ckb-std's default_alloc macro
 // and the buddy-alloc alloc implementation.

--- a/standalone-contract/src/main.rs
+++ b/standalone-contract/src/main.rs
@@ -8,11 +8,15 @@ extern crate alloc;
 mod tests;
 
 #[cfg(not(test))]
-use ckb_std::default_alloc;
-#[cfg(not(test))]
 ckb_std::entry!(program_entry);
 #[cfg(not(test))]
-default_alloc!();
+// By default, the following heap configuration is used:
+// * 16KB fixed heap
+// * 1.2MB(roughed up to be 16-byte aligned) dynamic heap
+// * Minimal memory block in dynamic heap is 64 bytes
+// For more details, please refer to ckb-std's default_alloc macro
+// and the buddy-alloc alloc implementation.
+ckb_std::default_alloc!(16384, 1258306, 64);
 
 pub fn program_entry() -> i8 {
     ckb_std::debug!("This is a sample contract!");


### PR DESCRIPTION
The default parameters to setup heap in ckb-std has been too convervative, this change bumps the heap size to a reasonable configuration, so we are less likely to encounter problems