### PR TITLE
Use firstword instead of lastword to locate current Makefile path

### DIFF
--- a/atomics-contract/Makefile
+++ b/atomics-contract/Makefile
@@ -1,6 +1,6 @@
 # We cannot use $(shell pwd), which will return unix path format on Windows,
 # making it hard to use.
-cur_dir = $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+cur_dir = $(dir $(abspath $(firstword $(MAKEFILE_LIST))))
 
 TOP := $(cur_dir)
 # RUSTFLAGS that are likely to be tweaked by developers. For example,

--- a/contract/Makefile
+++ b/contract/Makefile
@@ -1,6 +1,6 @@
 # We cannot use $(shell pwd), which will return unix path format on Windows,
 # making it hard to use.
-cur_dir = $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+cur_dir = $(dir $(abspath $(firstword $(MAKEFILE_LIST))))
 
 TOP := $(cur_dir)
 # RUSTFLAGS that are likely to be tweaked by developers. For example,

--- a/stack-reorder-contract/Makefile
+++ b/stack-reorder-contract/Makefile
@@ -1,6 +1,6 @@
 # We cannot use $(shell pwd), which will return unix path format on Windows,
 # making it hard to use.
-cur_dir = $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+cur_dir = $(dir $(abspath $(firstword $(MAKEFILE_LIST))))
 
 TOP := $(cur_dir)
 # RUSTFLAGS that are likely to be tweaked by developers. For example,

--- a/standalone-contract/Makefile
+++ b/standalone-contract/Makefile
@@ -1,6 +1,6 @@
 # We cannot use $(shell pwd), which will return unix path format on Windows,
 # making it hard to use.
-cur_dir = $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+cur_dir = $(dir $(abspath $(firstword $(MAKEFILE_LIST))))
 
 TOP := $(cur_dir)
 # RUSTFLAGS that are likely to be tweaked by developers. For example,

--- a/workspace/Makefile
+++ b/workspace/Makefile
@@ -1,6 +1,6 @@
 # We cannot use $(shell pwd), which will return unix path format on Windows,
 # making it hard to use.
-cur_dir = $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+cur_dir = $(dir $(abspath $(firstword $(MAKEFILE_LIST))))
 
 TOP := $(cur_dir)
 # RUSTFLAGS that are likely to be tweaked by developers. For example,


### PR DESCRIPTION
When `include` lines are used in Makefile, the newly included Makefile path will be appended to MAKEFILE_LIST. And using `lastword` to fetch current Makefile path would fail. This change alter the code to use firstword so as to fetch the top level Makefile path.