### PR TITLE
Use a generic `library` feature to setup contract

### DIFF
--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2021"
 ckb-std = "0.17.0"
 
 [features]
-native-simulator = ["ckb-std/native-simulator"]
+library = []
+native-simulator = ["library", "ckb-std/native-simulator"]

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -1,9 +1,9 @@
-#![cfg_attr(not(feature = "native-simulator"), no_std)]
+#![cfg_attr(not(feature = "library"), no_std)]
 #![allow(special_module_name)]
 #![allow(unused_attributes)]
-#[cfg(feature = "native-simulator")]
+#[cfg(feature = "library")]
 mod main;
-#[cfg(feature = "native-simulator")]
+#[cfg(feature = "library")]
 pub use main::program_entry;
 
 extern crate alloc;

--- a/contract/src/main.rs
+++ b/contract/src/main.rs
@@ -1,12 +1,12 @@
-#![cfg_attr(not(any(feature = "native-simulator", test)), no_std)]
+#![cfg_attr(not(any(feature = "library", test)), no_std)]
 #![cfg_attr(not(test), no_main)]
 
-#[cfg(any(feature = "native-simulator", test))]
+#[cfg(any(feature = "library", test))]
 extern crate alloc;
 
-#[cfg(not(any(feature = "native-simulator", test)))]
+#[cfg(not(any(feature = "library", test)))]
 ckb_std::entry!(program_entry);
-#[cfg(not(any(feature = "native-simulator", test)))]
+#[cfg(not(any(feature = "library", test)))]
 // By default, the following heap configuration is used:
 // * 16KB fixed heap
 // * 1.2MB(rounded up to be 16-byte aligned) dynamic heap


### PR DESCRIPTION
What `native-simulator` feature really means for a contract template, is that the contract shall be built as a native library crate. Apart from native simulators, there might well be other cases where a library crate is desired(e.g., fuzzing with sanitizers). This change change the code so a generic `library` feature sets up the code as a library crate. The `native-simulator` feature simple activates `library` feature.